### PR TITLE
Adjusted tables to support SUBJ_ID's of 30 chars (FT-743)

### DIFF
--- a/ddl/postgres/i2b2demodata/patient_dimension.sql
+++ b/ddl/postgres/i2b2demodata/patient_dimension.sql
@@ -19,7 +19,7 @@ CREATE TABLE patient_dimension (
     update_date timestamp without time zone,
     download_date timestamp without time zone,
     import_date timestamp without time zone,
-    sourcesystem_cd character varying(50),
+    sourcesystem_cd character varying(107),
     upload_id numeric(38,0)
 );
 

--- a/ddl/postgres/tm_lz/lt_src_clinical_data.sql
+++ b/ddl/postgres/tm_lz/lt_src_clinical_data.sql
@@ -4,7 +4,7 @@
 CREATE TABLE lt_src_clinical_data (
     study_id        character varying(25),
     site_id         character varying(50),
-    subject_id      character varying(20),
+    subject_id      character varying(30),
     visit_name      character varying(100),
     data_label      character varying(500),
     modifier_cd     character varying(100),

--- a/ddl/postgres/tm_lz/lz_src_clinical_data.sql
+++ b/ddl/postgres/tm_lz/lz_src_clinical_data.sql
@@ -4,7 +4,7 @@
 CREATE TABLE lz_src_clinical_data (
     study_id        character varying(25),
     site_id         character varying(50),
-    subject_id      character varying(20),
+    subject_id      character varying(30),
     visit_name      character varying(100),
     data_label      character varying(500),
     modifier_cd     character varying(100),

--- a/ddl/postgres/tm_wz/wrk_clinical_data.sql
+++ b/ddl/postgres/tm_wz/wrk_clinical_data.sql
@@ -4,7 +4,7 @@
 CREATE TABLE wrk_clinical_data (
     study_id        character varying(25),
     site_id         character varying(50),
-    subject_id      character varying(20),
+    subject_id      character varying(30),
     visit_name      character varying(100),
     data_label      character varying(500),
     modifier_cd     character varying(100),
@@ -14,7 +14,7 @@ CREATE TABLE wrk_clinical_data (
     category_cd     character varying(250),
     etl_job_id      bigint,
     etl_date        timestamp without time zone,
-    usubjid         character varying(200),
+    usubjid         character varying(107),
     category_path   character varying(1000),
     data_type       character varying(10),
     ctrl_vocab_code character varying(200)

--- a/ddl/postgres/tm_wz/wt_clinical_data_dups.sql
+++ b/ddl/postgres/tm_wz/wt_clinical_data_dups.sql
@@ -3,7 +3,7 @@
 --
 CREATE TABLE wt_clinical_data_dups (
     site_id     character varying(50),
-    subject_id  character varying(20),
+    subject_id  character varying(30),
     visit_name  character varying(100),
     data_label  character varying(500),
     category_cd character varying(250),

--- a/ddl/postgres/tm_wz/wt_subject_info.sql
+++ b/ddl/postgres/tm_wz/wt_subject_info.sql
@@ -2,7 +2,7 @@
 -- Name: wt_subject_info; Type: TABLE; Schema: tm_wz; Owner: -
 --
 CREATE TABLE wt_subject_info (
-    usubjid character varying(100),
+    usubjid character varying(107),
     age_in_years_num smallint,
     sex_cd character varying(50),
     race_cd character varying(50)


### PR DESCRIPTION
OpenClinica has subject names of 30 character max. To support the automatic
upload of data from OpenClinica we have to meet this.
From i2b2 I had to adapt patient_dimension.sourcesystem_cd study:visit:subject
