### PR TITLE
Assign permissions for more sequences

### DIFF
--- a/ddl/postgres/META/assign_support.sql
+++ b/ddl/postgres/META/assign_support.sql
@@ -86,18 +86,6 @@ BEGIN
             JOIN pg_roles r ON (c.relowner = r.oid)
         WHERE
             c.relkind IN ('r','S','v')
-            AND (
-                relkind <> 'S'
-                OR c.oid NOT IN ( --restriction to prevent error "cannot change owner; sequence is linked to table..."
-                    SELECT
-                        objid
-                    FROM
-                        pg_depend
-                    WHERE
-                        refobjsubid <> 0 -- dependent is a table
-                        AND deptype = 'a' -- dependency is automatic
-                )
-            )
         ORDER BY c.relkind = 'S'
     )
     UNION


### PR DESCRIPTION
We do not need to restrict us to manage permissions
just those sequences that in dependency with other db resources.
