### PR TITLE
Add i2b2 tag types.

### DIFF
--- a/ddl/postgres/i2b2metadata/_load_all.sql
+++ b/ddl/postgres/i2b2metadata/_load_all.sql
@@ -3,6 +3,8 @@
 \i i2b2metadata/custom_meta.sql
 \i i2b2metadata/i2b2.sql
 \i i2b2metadata/i2b2_secure.sql
+\i i2b2metadata/i2b2_tag_types.sql
+\i i2b2metadata/i2b2_tag_options.sql
 \i i2b2metadata/i2b2_tags.sql
 \i i2b2metadata/views/i2b2_trial_nodes.sql
 \i i2b2metadata/ont_db_lookup.sql

--- a/ddl/postgres/i2b2metadata/_misc.sql
+++ b/ddl/postgres/i2b2metadata/_misc.sql
@@ -1,4 +1,14 @@
 --
+-- Name: i2b2_tag_options_tag_option_id_seq; Type: SEQUENCE OWNED BY; Schema: i2b2metadata; Owner: -
+--
+ALTER SEQUENCE i2b2_tag_options_tag_option_id_seq OWNED BY i2b2_tag_options.tag_option_id;
+
+--
+-- Name: i2b2_tag_types_tag_type_id_seq; Type: SEQUENCE OWNED BY; Schema: i2b2metadata; Owner: -
+--
+ALTER SEQUENCE i2b2_tag_types_tag_type_id_seq OWNED BY i2b2_tag_types.tag_type_id;
+
+--
 -- Name: seq_concept_code; Type: SEQUENCE; Schema: i2b2metadata; Owner: -
 --
 CREATE SEQUENCE seq_concept_code

--- a/ddl/postgres/i2b2metadata/dependencies.php
+++ b/ddl/postgres/i2b2metadata/dependencies.php
@@ -4,5 +4,13 @@ $dependencies = array (
   array (
     0 => 'i2b2',
   ),
+  'i2b2_tag_options' => 
+  array (
+    0 => 'i2b2_tag_types',
+  ),
+  'i2b2_tags' => 
+  array (
+    0 => 'i2b2_tag_options',
+  ),
 )
 ;

--- a/ddl/postgres/i2b2metadata/i2b2_tag_options.sql
+++ b/ddl/postgres/i2b2metadata/i2b2_tag_options.sql
@@ -1,0 +1,41 @@
+--
+-- Name: i2b2_tag_options_tag_option_id_seq; Type: SEQUENCE; Schema: i2b2metadata; Owner: -
+--
+CREATE SEQUENCE i2b2_tag_options_tag_option_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: i2b2_tag_options; Type: TABLE; Schema: i2b2metadata; Owner: -
+--
+CREATE TABLE i2b2_tag_options (
+    tag_option_id integer NOT NULL,
+    tag_type_id bigint NOT NULL,
+    value character varying(1000)
+);
+
+--
+-- Name: tag_option_id; Type: DEFAULT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tag_options ALTER COLUMN tag_option_id SET DEFAULT nextval('i2b2_tag_options_tag_option_id_seq'::regclass);
+
+--
+-- Name: i2b2_tag_options_pkey; Type: CONSTRAINT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tag_options
+    ADD CONSTRAINT i2b2_tag_options_pkey PRIMARY KEY (tag_option_id);
+
+--
+-- Name: idx_i2b2_tag_option_pk; Type: INDEX; Schema: i2b2metadata; Owner: -
+--
+CREATE UNIQUE INDEX idx_i2b2_tag_option_pk ON i2b2_tag_options USING btree (tag_option_id);
+
+--
+-- Name: i2b2_tag_options_tag_type_fk; Type: FK CONSTRAINT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tag_options
+    ADD CONSTRAINT i2b2_tag_options_tag_type_fk FOREIGN KEY (tag_type_id) REFERENCES i2b2_tag_types(tag_type_id);
+

--- a/ddl/postgres/i2b2metadata/i2b2_tag_types.sql
+++ b/ddl/postgres/i2b2metadata/i2b2_tag_types.sql
@@ -1,0 +1,45 @@
+--
+-- Name: i2b2_tag_types_tag_type_id_seq; Type: SEQUENCE; Schema: i2b2metadata; Owner: -
+--
+CREATE SEQUENCE i2b2_tag_types_tag_type_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+--
+-- Name: i2b2_tag_types; Type: TABLE; Schema: i2b2metadata; Owner: -
+--
+CREATE TABLE i2b2_tag_types (
+    tag_type_id integer NOT NULL,
+    tag_type character varying(255) NOT NULL,
+    solr_field_name character varying(255),
+    node_type character varying(255) NOT NULL,
+    value_type character varying(255) NOT NULL,
+    shown_if_empty boolean,
+    index integer
+);
+
+--
+-- Name: tag_type_id; Type: DEFAULT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tag_types ALTER COLUMN tag_type_id SET DEFAULT nextval('i2b2_tag_types_tag_type_id_seq'::regclass);
+
+--
+-- Name: i2b2_tag_types_node_type_tag_type_unique; Type: CONSTRAINT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tag_types
+    ADD CONSTRAINT i2b2_tag_types_node_type_tag_type_unique UNIQUE (node_type, tag_type);
+
+--
+-- Name: i2b2_tag_types_pkey; Type: CONSTRAINT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tag_types
+    ADD CONSTRAINT i2b2_tag_types_pkey PRIMARY KEY (tag_type_id);
+
+--
+-- Name: idx_i2b2_tag_type_pk; Type: INDEX; Schema: i2b2metadata; Owner: -
+--
+CREATE UNIQUE INDEX idx_i2b2_tag_type_pk ON i2b2_tag_types USING btree (tag_type_id);
+

--- a/ddl/postgres/i2b2metadata/i2b2_tags.sql
+++ b/ddl/postgres/i2b2metadata/i2b2_tags.sql
@@ -6,7 +6,8 @@ CREATE TABLE i2b2_tags (
     path character varying(400) NOT NULL,
     tag character varying(1000),
     tag_type character varying(400) NOT NULL,
-    tags_idx integer NOT NULL
+    tags_idx integer NOT NULL,
+    tag_option_id integer
 );
 
 --
@@ -36,6 +37,12 @@ SET default_with_oids = false;
 -- Name: trg_i2b2_tag_id; Type: TRIGGER; Schema: i2b2metadata; Owner: -
 --
 CREATE TRIGGER trg_i2b2_tag_id BEFORE INSERT ON i2b2_tags FOR EACH ROW EXECUTE PROCEDURE tf_trg_i2b2_tag_id();
+
+--
+-- Name: i2b2_tags_option_id_fk; Type: FK CONSTRAINT; Schema: i2b2metadata; Owner: -
+--
+ALTER TABLE ONLY i2b2_tags
+    ADD CONSTRAINT i2b2_tags_option_id_fk FOREIGN KEY (tag_option_id) REFERENCES i2b2_tag_options(tag_option_id) ON DELETE SET NULL;
 
 --
 -- Name: seq_i2b2_data_id; Type: SEQUENCE; Schema: i2b2metadata; Owner: -


### PR DESCRIPTION
Extending the i2b2metadata schema with tag types. Only for Postgres for the moment.
